### PR TITLE
Multiple calendars support

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ These are the config variables you can configure in the `environment` section of
 
 Variable | Required | Default | Description
 --- | --- | --- | ---
-ICS_URL | Yes | | URL of the ICS calendar feed
+ICS_URL | Yes | | URL of the ICS calendar feeds (add as much as an environment variable can hold, separated by a "\|")
 LAT | Yes | | Latitude in decimal for the weather forecast location
 LNG | Yes | | Longitude in decimal for the weather forecast location
 OWM_API_KEY | Yes | | [OpenWeatherMap API key](https://openweathermap.org/api/one-call-3) to retrieve weather forecast
@@ -73,6 +73,7 @@ NUM_CAL_DAYS_TO_QUERY | No | 30 | Number of days to query from the calendar
 SHOW_ADDITIONAL_WEATHER | No | False | Whether to show "Feels Like" temperature and UV index for the next hour
 SHOW_MOON_PHASE | No | False | Whether to show the current moon phase next to the date
 WEATHER_UNITS | No | metric | Units of measurement for the temperature, `metric` and `imperial` units are available
+SHOW_CALENDAR_NAME | No | False | Show the calendar name on the event line (useful for multiple calendars)
 
 ## Development
 

--- a/src/config.py
+++ b/src/config.py
@@ -33,6 +33,7 @@ class DashboardConfig:
     SHOW_ADDITIONAL_WEATHER: bool = bool(os.getenv("SHOW_ADDITIONAL_WEATHER", False))
     SHOW_MOON_PHASE: bool = bool(os.getenv("SHOW_MOON_PHASE", False))
     NUM_DAYS_IN_TEMPLATE: int = 7  # Not configurable because it's hard-coded in the HTML template
+    SHOW_CALENDAR_NAME: bool = bool(os.getenv("SHOW_CALENDAR_NAME", False))
 
     def get_config():
         global _current_config

--- a/src/ics_cal/icshelper.py
+++ b/src/ics_cal/icshelper.py
@@ -23,52 +23,57 @@ class IcsHelper:
         event_list = []
 
         self.logger.info("Retrieving events from ICS...")
-        response = requests.get(ics_url)
-        if response.ok:
-            cal = icalendar.Calendar.from_ical(response.text)
-        else:
-            self.logger.error(f"Received an error when downloading ICS: {response.text}")
-            sys.exit(1)
-
-        events = recurring_ical_events.of(cal).between(calStartDatetime, calEndDatetime)
-        local_timezone = pytz.timezone(localTZ)
-
-        for event in events:
-            new_event = {"summary": str(event.get("SUMMARY"))}
-
-            if "LOCATION" in event:
-                new_event["location"] = str(event.get("LOCATION"))
-
-            event_start = event.get("DTSTART").dt
-            event_end = event.get("DTEND").dt
-
-            if isinstance(event_start, dt.datetime):
-                new_event["allday"] = False
-                new_event["startDatetime"] = event_start.astimezone(local_timezone)
-                new_event["endDatetime"] = event_end.astimezone(local_timezone)
-            elif isinstance(event_start, dt.date):
-                new_event["allday"] = True
-                # Convert date into datetime at midnight
-                new_event["startDatetime"] = local_timezone.localize(
-                    dt.datetime.combine(event_start, dt.time(0, 0))
-                )
-                new_event["endDatetime"] = local_timezone.localize(
-                    dt.datetime.combine(event_end, dt.time(0, 0))
-                ) - dt.timedelta(minutes=1)
+        ics_urls = ics_url.split("|")
+        for ics_url in ics_urls:
+            response = requests.get(ics_url)
+            if response.ok:
+                cal = icalendar.Calendar.from_ical(response.text)
             else:
-                raise TypeError(f"Unknown type {type(event_start)} for DTSTART")
+                self.logger.error(f"Received an error when downloading ICS: {response.text}")
+                sys.exit(1)
 
-            new_event["isMultiday"] = (
-                new_event["endDatetime"] - new_event["startDatetime"]
-            ) > dt.timedelta(days=1)
+            cal_name = cal['X-WR-CALNAME']
 
-            if (
-                new_event["endDatetime"] >= calStartDatetime
-                and new_event["startDatetime"] < calEndDatetime
-            ):
-                # Don't show past days for ongoing multiday event
-                new_event["startDatetime"] = max(new_event["startDatetime"], calStartDatetime)
+            events = recurring_ical_events.of(cal).between(calStartDatetime, calEndDatetime)
+            local_timezone = pytz.timezone(localTZ)
 
-                event_list.append(new_event)
+            for event in events:
+                new_event = {"summary": str(event.get("SUMMARY"))}
+
+                if "LOCATION" in event:
+                    new_event["location"] = str(event.get("LOCATION"))
+
+                event_start = event.get("DTSTART").dt
+                event_end = event.get("DTEND").dt
+
+                if isinstance(event_start, dt.datetime):
+                    new_event["allday"] = False
+                    new_event["startDatetime"] = event_start.astimezone(local_timezone)
+                    new_event["endDatetime"] = event_end.astimezone(local_timezone)
+                elif isinstance(event_start, dt.date):
+                    new_event["allday"] = True
+                    # Convert date into datetime at midnight
+                    new_event["startDatetime"] = local_timezone.localize(
+                        dt.datetime.combine(event_start, dt.time(0, 0))
+                    )
+                    new_event["endDatetime"] = local_timezone.localize(
+                        dt.datetime.combine(event_end, dt.time(0, 0))
+                    ) - dt.timedelta(minutes=1)
+                else:
+                    raise TypeError(f"Unknown type {type(event_start)} for DTSTART")
+
+                new_event["isMultiday"] = (
+                    new_event["endDatetime"] - new_event["startDatetime"]
+                ) > dt.timedelta(days=1)
+
+                if (
+                    new_event["endDatetime"] >= calStartDatetime
+                    and new_event["startDatetime"] < calEndDatetime
+                ):
+                    # Don't show past days for ongoing multiday event
+                    new_event["startDatetime"] = max(new_event["startDatetime"], calStartDatetime)
+                    new_event["calendarName"] = cal_name
+
+                    event_list.append(new_event)
 
         return sorted(event_list, key=lambda k: k["startDatetime"])

--- a/src/render/css/styles.css
+++ b/src/render/css/styles.css
@@ -50,6 +50,10 @@ h1, h2, h3, p, span {
     color: gray
 }
 
+.event-calendar-name {
+    font-size: smaller;
+}
+
 .weather-forecast {
     font-family: "Lexend-Regular", sans-serif;
     font-size: 1.8rem;

--- a/src/render/render.py
+++ b/src/render/render.py
@@ -141,16 +141,16 @@ class RenderHelper:
                         + "</span> "
                         + event["summary"]
                     )
-                    if "location" in event:
-                        cal_events_text += (
-                            '<span class="event-location"> at ' + event["location"] + "</span>"
-                        )
-                    if self.cfg.SHOW_CALENDAR_NAME:
-                        cal_events_text += (
-                            '<span class="event-calendar-name"> '
-                            + event["calendarName"]
-                            + "</span>"
-                        )
+                if "location" in event:
+                    cal_events_text += (
+                        '<span class="event-location"> at ' + event["location"] + "</span>"
+                    )
+                if self.cfg.SHOW_CALENDAR_NAME:
+                    cal_events_text += (
+                        '<span class="event-calendar-name"> '
+                        + event["calendarName"]
+                        + "</span>"
+                    )
                 cal_events_text += "</div>\n"
             if d == current_date:
                 cal_events_days.append("Today")

--- a/src/render/render.py
+++ b/src/render/render.py
@@ -141,10 +141,16 @@ class RenderHelper:
                         + "</span> "
                         + event["summary"]
                     )
-                if "location" in event:
-                    cal_events_text += (
-                        '<span class="event-location"> at ' + event["location"] + "</span>"
-                    )
+                    if "location" in event:
+                        cal_events_text += (
+                            '<span class="event-location"> at ' + event["location"] + "</span>"
+                        )
+                    if self.cfg.SHOW_CALENDAR_NAME:
+                        cal_events_text += (
+                            '<span class="event-calendar-name"> '
+                            + event["calendarName"]
+                            + "</span>"
+                        )
                 cal_events_text += "</div>\n"
             if d == current_date:
                 cal_events_days.append("Today")


### PR DESCRIPTION
Allows multiple calendar to be added to the ICS_URL configuration in order to show more than one.
Added a configuration to show the calendar name (in most of the cases the line becomes quite long and someone might prefer not to show it).